### PR TITLE
limit package installation to python 3.6 to 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,10 @@ setuptools.setup(
         "cryptography==36.0.1",
     ],
     classifiers=[
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Operating System :: OS Independent",
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("readme.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="deploifai",
-    version="0.1.3",
+    version="0.1.4",
     author="Deploifai Limited",
     description="Deploifai CLI",
     long_description=long_description,


### PR DESCRIPTION
- limit package installation to 3.6-3.9
- bump package version to 0.1.4
