### PR TITLE
use local cloud profile credentials for aws when creating cloud profile

### DIFF
--- a/deploifai/cloud_profile/create.py
+++ b/deploifai/cloud_profile/create.py
@@ -63,7 +63,9 @@ def create(context: DeploifaiContextObj, name: str, provider: str):
         profiles = s.available_profiles
         profile = 'default'
         if not profiles:
-            click.secho('No AWS credentials found. Please set this up', fg="red")
+            click.secho('AWS credentials not found. Please set it up with "aws configure", or go to '
+                        'https://docs.deploif.ai/cloud-services/connect-your-account/aws to learn how to create AWS '
+                        'credentials for Deploifai on the dashboard.', fg="red")
             raise click.Abort()
         if len(profiles) > 1:
             try:


### PR DESCRIPTION
- Cloud profile create now supports `-p` or `--provider` flag to specify the provider without going through a prompt
- boto3 is used to get local AWS credentials (from .aws)
- These credentials are used to create an IAM user with a username specified by the provided cloud profile name
- After attaching policies to the user, another set of credentials are generated to create the cloud profile on deploifai
- If no AWS local credentials can be found, the user will be prompted to enter the credentials manually

** messages and error handling can be further cleaned up